### PR TITLE
fix(test): align query-param GET mocks with real serialization (#25)

### DIFF
--- a/__tests__/apsoClient.test.ts
+++ b/__tests__/apsoClient.test.ts
@@ -25,17 +25,23 @@ describe('Apso SDK Client', () => {
   });
 
   test('GET request with where and limit', async () => {
-    mock.onGet('/HopperLoads?filter[status]=active&limit=10').reply(200, { data: 'mockData' });
+    mock.onGet(/^\/HopperLoads/).reply(200, { data: 'mockData' });
 
     const data = await client.entity('HopperLoads').where({ status: 'active' }).limit(10).get();
     expect(data).toEqual({ data: 'mockData' });
+    expect(decodeURIComponent(mock.history.get[0].url!)).toBe(
+      '/HopperLoads?filter[0]=status||$eq||active&limit=10'
+    );
   });
 
   test('GET request with join and orderBy', async () => {
-    mock.onGet('/HopperLoads?join=relatedEntity&sort[created_at]=ASC').reply(200, { data: 'mockData' });
+    mock.onGet(/^\/HopperLoads/).reply(200, { data: 'mockData' });
 
     const data = await client.entity('HopperLoads').join(['relatedEntity']).orderBy({ created_at: 'ASC' }).get();
     expect(data).toEqual({ data: 'mockData' });
+    expect(decodeURIComponent(mock.history.get[0].url!)).toBe(
+      '/HopperLoads?join[0]=relatedEntity&sort[0]=created_at,ASC'
+    );
   });
 
   test('POST request with data', async () => {
@@ -80,7 +86,7 @@ describe('Apso SDK Client', () => {
 
   describe('Semantic CRUD Methods', () => {
     test('findMany() returns paginated data', async () => {
-      mock.onGet('/Product?filter[status]=active&limit=20').reply(200, {
+      mock.onGet(/^\/Product/).reply(200, {
         data: [{ id: 1, name: 'Product 1' }],
         total: 100,
         page: 1,
@@ -94,6 +100,9 @@ describe('Apso SDK Client', () => {
         page: 1,
         pageCount: 5
       });
+      expect(decodeURIComponent(mock.history.get[0].url!)).toBe(
+        '/Product?filter[0]=status||$eq||active&limit=20'
+      );
     });
 
     test('findOne() with id filter fetches single record', async () => {
@@ -104,12 +113,15 @@ describe('Apso SDK Client', () => {
     });
 
     test('findOne() with non-id filter uses limit=1', async () => {
-      mock.onGet('/Product?filter[status]=active&limit=1').reply(200, {
+      mock.onGet(/^\/Product/).reply(200, {
         data: [{ id: 1, name: 'Active Product' }]
       });
 
       const record = await client.entity('Product').where({ status: 'active' }).findOne();
       expect(record).toEqual({ id: 1, name: 'Active Product' });
+      expect(decodeURIComponent(mock.history.get[0].url!)).toBe(
+        '/Product?filter[0]=status||$eq||active&limit=1'
+      );
     });
 
     test('create() posts new record', async () => {


### PR DESCRIPTION
## Summary
Fixes the 4 pre-existing unit-test failures on `main` (issue #25): `axios-mock-adapter` 404s on query-param GET matching. Suite now 14/14 green.

## Root cause
The 4 failing tests asserted an **imagined** query format:
- `filter[status]=active`, `sort[created_at]=ASC`, `join=relatedEntity`

The client actually emits **nestjsx/crud** format (the format the Apso server expects):
- `filter[0]=status||$eq||active`, `sort[0]=created_at,ASC`, `join[0]=relatedEntity`

axios then percent-encodes those in the request URL (`%5B0%5D`, `%7C%7C%24eq`), and `axios-mock-adapter@2.x` matches URLs by **exact string comparison** (`isUrlMatching`), so the mock strings never matched → 404.

The client's serialization is the correct, shipped behavior. The **tests** were wrong.

## Fix
For the 4 tests, match on the resource path and assert the exact **decoded** request URL via `mock.history`:

```ts
mock.onGet(/^\/HopperLoads/).reply(200, { data: 'mockData' });
// ...
expect(decodeURIComponent(mock.history.get[0].url!)).toBe(
  '/HopperLoads?filter[0]=status||$eq||active&limit=10'
);
```

This keeps the assertions readable and exact (no percent-encoded literals) and makes CI catch real serialization regressions going forward.

**No SDK runtime change** — only `__tests__/apsoClient.test.ts`. `npm run build` (tsc) passes.

## Test
- `npx jest`: PASS 14 / FAIL 0 (was 10 pass / 4 fail)

## Note
Merging to `main` publishes via `onPushToMain` (merge = release) — leaving the merge to Matt.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)