### PR TITLE
ci(security): pin third-party actions, drop npmrc echo, least-privilege permissions (#29)

### DIFF
--- a/.github/workflows/failureNotifications.yml
+++ b/.github/workflows/failureNotifications.yml
@@ -8,6 +8,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   failure-notify:
     runs-on: ubuntu-latest
@@ -15,7 +18,7 @@ jobs:
     steps:
       - name: Announce Failure
         id: slack
-        uses: slackapi/slack-github-action@v1.21.0
+        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # v1.21.0
         env:
           # for non-CLI-team-owned plugins, you can send this anywhere you like
           SLACK_WEBHOOK_URL: ${{ secrets.CLI_ALERTS_SLACK_WEBHOOK }}

--- a/.github/workflows/notify-slack-on-pr-open.yml
+++ b/.github/workflows/notify-slack-on-pr-open.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,4 +23,4 @@ jobs:
         PULL_REQUEST_REPO: ${{ github.event.pull_request.head.repo.name }}
         PULL_REQUEST_TITLE : ${{ github.event.pull_request.title }}
         PULL_REQUEST_URL : ${{ github.event.pull_request.html_url }}
-      uses: salesforcecli/github-workflows/.github/actions/prNotification@main
+      uses: salesforcecli/github-workflows/.github/actions/prNotification@5bb4ac8bb990c61c3e8cc9f2eb1c058a791b3884 # main @ 2026-07

--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # bump commit, push tags, create GitHub releases
     steps:
     - uses: actions/checkout@v3
       with:
@@ -26,7 +28,7 @@ jobs:
 
     - name: Bump version and tag
       id: bump_version
-      uses: phips28/gh-action-bump-version@master
+      uses: phips28/gh-action-bump-version@fdad52b3b3bbe8fad96b8ca18c56127a96f603db # v11.0.7
       with:
         tag-prefix: 'v'  # Set this to 'v' if you want your tags like 'v1.0.0'
       env:
@@ -78,7 +80,6 @@ jobs:
     - name: Setup NPM Authentication
       run: |
         echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-        cat ~/.npmrc
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
     

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
         types: [opened, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #29. Mirror of apsoai/cli#113. SHA-pins `phips28/gh-action-bump-version`, `salesforcecli/…/prNotification`, `slackapi/slack-github-action`; removes `cat ~/.npmrc` (token echo); adds least-privilege `permissions:` (contents:read default, contents:write on the publish job). `next-docs.yml` already hardened, untouched. No publish-behavior change. **Merge is a maintainer call — sdk auto-publishes on merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)